### PR TITLE
Don't prepend / to key if folderPathOptions === 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -271,14 +271,16 @@ class S3Cache {
     }
 
     // Add a folder structure based on the hash.
-    const urlChunks = []
-    for( let depth = 0; depth < options.folderPathDepth; depth++ ) {
-      const begin = depth * options.folderPathChunkSize
-      const end = begin + options.folderPathChunkSize
-      urlChunks.push(key.slice(begin, end))
-    }
+    if( options.folderPathDepth !== 0 ) {
+        const urlChunks = []
+        for( let depth = 0; depth < options.folderPathDepth; depth++ ) {
+          const begin = depth * options.folderPathChunkSize
+          const end = begin + options.folderPathChunkSize
+          urlChunks.push(key.slice(begin, end))
+        }
 
-    key = urlChunks.join('/') + '/' + key
+        key = urlChunks.join('/') + '/' + key
+    }
 
     // Prefix it if desired
     if( options.pathPrefix !== '' ) {

--- a/src/index.js
+++ b/src/index.js
@@ -272,14 +272,14 @@ class S3Cache {
 
     // Add a folder structure based on the hash.
     if( options.folderPathDepth !== 0 ) {
-        const urlChunks = []
-        for( let depth = 0; depth < options.folderPathDepth; depth++ ) {
-          const begin = depth * options.folderPathChunkSize
-          const end = begin + options.folderPathChunkSize
-          urlChunks.push(key.slice(begin, end))
-        }
+      const urlChunks = []
+      for( let depth = 0; depth < options.folderPathDepth; depth++ ) {
+        const begin = depth * options.folderPathChunkSize
+        const end = begin + options.folderPathChunkSize
+        urlChunks.push(key.slice(begin, end))
+      }
 
-        key = urlChunks.join('/') + '/' + key
+      key = urlChunks.join('/') + '/' + key
     }
 
     // Prefix it if desired


### PR DESCRIPTION
Fixes: Setting `folderPathOptions: 0` causes an empty array of chunks to be joined with the cache path, causing a key `this/is/my/key` to become `/this/is/my/key`. This causes S3 to store the file in a root folder with a name set to the empty string.