### PR TITLE
Return undefined on cache-miss

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ const s3CacheStore = new S3Cache({
 
 const s3Cache = cacheManager.caching({
   store: s3CacheStore,
-  isCacheableValue: value => value !== undefined && value !== null,
 })
 
 s3Cache.set('foo', 'bar', {ttl: 360}, (err) => {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const s3CacheStore = new S3Cache({
 
 const s3Cache = cacheManager.caching({
   store: s3CacheStore,
+  isCacheableValue: value => value !== undefined && value !== null,
 })
 
 s3Cache.set('foo', 'bar', {ttl: 360}, (err) => {

--- a/src/index.js
+++ b/src/index.js
@@ -379,13 +379,13 @@ class S3Cache {
           // If we're being proactive, delete the object.
           if( currentOptions.proactiveExpiry ) {
             this._log.get.info(key, ' is expired, deleting it')
-            this.del(key, (err, result) => err ? waterCb(err, null) : waterCb(null, null))
+            this.del(key, (err, result) => err ? waterCb(err, undefined) : waterCb(null, undefined))
             return
           } else {
             this._log.get.info(key, ' is expired, ignoring result')
           }
 
-          waterCb(null, null)
+          waterCb(null, undefined)
           return
         }
 
@@ -395,7 +395,7 @@ class S3Cache {
     ], (err, result) => {
       if( err instanceof Error && err.statusCode === 404 ) {
         this._log.get.trace(key, ' not found according to s3' )
-        cb(null, null)
+        cb(null, undefined)
         return
       }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -94,7 +94,7 @@ describe('basic function test', () => {
   test('fail to get string with different case', done => {
     cache.get(utils.randomizeCase(testKey), (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })
@@ -144,7 +144,7 @@ describe('basic function test', () => {
   test('fail to get deleted string', done => {
     cache.get(testKey, (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })

--- a/test/cacheManager.test.js
+++ b/test/cacheManager.test.js
@@ -42,7 +42,7 @@ describe('basic function test', () => {
     cache.get(id, function (err, result) {
       if( err ) { return cb(err) }
 
-      if( result !== null ) {
+      if( result !== undefined ) {
         return cb(null, result)
       }
 

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -62,7 +62,7 @@ describe('logging', () => {
       seriesCb => cache.del(testKey, seriesCb),
       seriesCb => cache.get(testKey, (err, value) => {
         expect(err).toBeNull()
-        expect(value).toBeNull()
+        expect(value).toBeUndefined()
         seriesCb()
       }),
     ], (err, results) => {

--- a/test/normalization.test.js
+++ b/test/normalization.test.js
@@ -87,7 +87,7 @@ describe('key normalization as url', () => {
   test('fail to get same string with random case on url', done => {
     cache.get(utils.randomizeCase(testKey), (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })
@@ -119,7 +119,7 @@ describe('key normalization as url', () => {
   test('fail to get same string with random case on poorly formed url', done => {
     cache.get(utils.randomizeCase(testPoorlyFormedKey), (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })
@@ -188,7 +188,7 @@ describe('key normalization as path', () => {
   test('fail to get same string with random case on path', done => {
     cache.get(utils.randomizeCase(testKey), (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })
@@ -208,7 +208,7 @@ describe('key normalization as path', () => {
   test('fail to get same string with random case on poorly formed path', done => {
     cache.get(utils.randomizeCase(testPoorlyFormedKey), (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })

--- a/test/ttl.test.js
+++ b/test/ttl.test.js
@@ -63,7 +63,7 @@ describe('get/set/del with ttl', () => {
   test('fail to get expired string', done => {
     cache.get(testKey, (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })
@@ -71,7 +71,7 @@ describe('get/set/del with ttl', () => {
   test('check that key still exists', done => {
     cache.get(testKey, (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })
@@ -79,7 +79,7 @@ describe('get/set/del with ttl', () => {
   test('fail to get expired string proactively', done => {
     cache.get(testKey, {proactiveExpiry: true}, (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })
@@ -87,7 +87,7 @@ describe('get/set/del with ttl', () => {
   test('check that key does not exist', done => {
     cache.get(testKey, (err, value) => {
       expect(err).toBeNull()
-      expect(value).toBeNull()
+      expect(value).toBeUndefined()
       done()
     })
   })


### PR DESCRIPTION
Not entirely sure this is the correct fix, but on a cache-miss cache-manager-S3 is returning a `null` as the value. cache-manager considers `value !== undefined` to be cacheable, and so happily returns the `null` as the value if you use `wrap`.

Using isCacheableValue fixes this. However it's probably a "more correct" fix if cache-manager-S3 returned `undefined` on a cache-miss. I don't have a PR for that though.