### PR TITLE
Allow credentials to be handled by aws-sdk

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,17 +130,20 @@ class S3Cache {
       }
     }
 
-    validateOption('accessKey')
-    validateOption('secretKey')
     validateOption('bucket')
 
     // Translate passed in params to S3 constructor params.
     let constructorOptions = {
-      accessKeyId: this.options.accessKey,
-      secretAccessKey: this.options.secretKey,
       params: {
         Bucket: this.options.bucket,
       },
+    }
+    // Only set identity values if passed. Let AWS-sdk handle picking them up from the environment.
+    if ('accessKey' in this.options) {
+        constructorOptions.accessKeyId = this.options.accessKey;
+    }
+    if ('secretKey' in this.options) {
+        constructorOptions.secretAccessKey = this.options.secretKey;
     }
 
     // If s3Options is provided, merge it with our constructorOptions object and create S3 object

--- a/src/index.js
+++ b/src/index.js
@@ -139,11 +139,11 @@ class S3Cache {
       },
     }
     // Only set identity values if passed. Let AWS-sdk handle picking them up from the environment.
-    if ('accessKey' in this.options) {
-        constructorOptions.accessKeyId = this.options.accessKey;
-    }
-    if ('secretKey' in this.options) {
-        constructorOptions.secretAccessKey = this.options.secretKey;
+    if( 'accessKey' in this.options || 'secretKey' in this.options ) {
+      validateOption('accessKey')
+      validateOption('secretKey')
+      constructorOptions.accessKeyId = this.options.accessKey
+      constructorOptions.secretAccessKey = this.options.secretKey
     }
 
     // If s3Options is provided, merge it with our constructorOptions object and create S3 object


### PR DESCRIPTION
Allowing credentials to be handled by aws-sdk allows profiles to work, temporary credentials based on roles, and a bunch of other magic to work.